### PR TITLE
[여행루트] 백엔드 수정에 따른 작성, 수정, 상세 페이지 관련 수정 및 예외처리

### DIFF
--- a/routes/create/index.html
+++ b/routes/create/index.html
@@ -123,7 +123,7 @@
 								<div class="col-xxs-12 col-xs-6 mt alternate">
 									<div class="input-field">
 										<label for="duration">여행 일수:</label>
-										<input type="text" class="form-control" id="route-duration"
+										<input type="number" min="1" class="form-control" id="route-duration"
 											placeholder="숫자로만 작성" />
 									</div>
 								</div>
@@ -131,7 +131,8 @@
 								<div class="col-xxs-12 col-xs-6 mt alternate">
 									<div class="input-field">
 										<label for="cost">여행 비용:</label>
-										<input type="text" class="form-control" id="route-cost" placeholder="숫자로만 작성" />
+										<input type="number" min="0" class="form-control" id="route-cost"
+											placeholder="숫자로만 작성" />
 									</div>
 								</div>
 

--- a/routes/create/route_create.js
+++ b/routes/create/route_create.js
@@ -31,9 +31,14 @@ function handleCreateRoute(event) {
     formData.append('content', content);
 
     // 목적지를 순차적으로 기입
-    spotsId.forEach((spot) =>
-        formData.append('spots', spot)
-    )
+    let spots = [];
+    let order = 1;
+
+    for (let i = 0; i < spotsId.length; i++) {
+        let spotInfo = { spot: spotsId[i], order: order++, day: 1 };
+        spots.push(spotInfo);
+    }
+    formData.append('spots', JSON.stringify(spots));
 
     // 이미지가 있는 경우에만 formdata에 기입
     if (image) {

--- a/routes/create/route_create.js
+++ b/routes/create/route_create.js
@@ -19,6 +19,21 @@ function handleCreateRoute(event) {
     const image = document.getElementById('route-image').files[0];
     const content = document.getElementById('route-content').value;
 
+    // duration과 cost는 숫자로만 받아야함
+    const durationValue = parseInt(duration);
+    const costValue = parseInt(cost);
+
+    // duration과 cost는 양의 정수만 받아야함
+    if (isNaN(durationValue) || !Number.isInteger(durationValue) || durationValue < 1) {
+        alert("여행일수는 1이상의 숫자만 기재할 수 있습니다");
+        return;
+    }
+
+    if (isNaN(costValue) || !Number.isInteger(costValue) || costValue < 0) {
+        alert("여행비용은 0이상의 숫자만 기재할 수 있습니다");
+        return;
+    }
+
     // const areas = 
     const areas = JSON.stringify({ area: area, sigungu: sigungu });
 

--- a/routes/detail/route_detail.css
+++ b/routes/detail/route_detail.css
@@ -103,3 +103,7 @@
     transform: scale(1.1);
     opacity: 0.5;
 }
+
+#commnet-name:hover {
+    color: #5c3c25;
+}

--- a/routes/detail/route_detail.js
+++ b/routes/detail/route_detail.js
@@ -166,10 +166,10 @@ async function routeRating(route_id) {
 // 여행루트 상세 페이지 로드 함수
 async function viewRouteDetail() {
     const route = await getRouteDetail();   // 해당 여행 루트 게시글의 데이터
-
     const area_id = route.areas[0].area // route의 시/도 id 
     const sigungu_id = route.areas[0].sigungu   // route의 시군구 id
-    const spot_ids = route.spots
+    const spots = route.spots
+
     const rate_half_up = Math.round(route.rate * 10) / 10;  // 평점 반올림
 
     const area = await getRouteArea(area_id);   // 시/도의 이름
@@ -197,11 +197,11 @@ async function viewRouteDetail() {
     route_content.innerText = route.content
     route_user.innerText = route.user.nickname
 
-    // route_user.addEventListener('click', function () {
-    //     window.location.href = `/users/mypage/index.html?id=${route.user.id}`;
-    // });
-
     // 수정버튼 수정페이지 링크 부여
+    route_user.addEventListener('click', function () {
+        window.location.href = `/users/mypage/index.html?id=${route.user.id}`;
+    });
+
     const route_user_id = route.user.id;
     // 유저의 로컬스토리지에 페이로드가 있다면
     if (userInfo !== null) {
@@ -216,32 +216,30 @@ async function viewRouteDetail() {
     }
 
     // 목적지 목록에 목적지 순차 부여
-    let spotCount = 1
     let spot_image = ""
     let spot_addr = ""
 
-    for (let spot of spot_ids) {
-        if (spot.firstimage) {
-            spot_image = spot.firstimage
+    for (let spotData of spots) {
+        if (spotData.spot.firstimage) {
+            spot_image = spotData.spot.firstimage
         } else {
             spot_image = "/images/place-1.jpg"
         }
-        if (spot.addr1) {
-            spot_addr = spot.addr1
+        if (spotData.spot.addr1) {
+            spot_addr = spotData.spot.addr1
         } else {
             spot_addr = "기록된 주소가 없습니다."
         }
         route_spots.innerHTML += `
-        <a class="row-spot" style="margin: 0;" id="review_detail_spot_cardbox" href="/spots/index.html?id=${spot.id}">
+        <a class="row-spot" style="margin: 0;" id="review_detail_spot_cardbox" href="/spots/index.html?id=${spotData.spot.id}">
             <div class="col-md-4" style="height:100px; padding:0; overflow: hidden;">
                 <img class="img-responsive" src="${spot_image}" alt="방문지 이미지" id="review_detail_spot_image" style="height: 100%; width: 100%; object-fit: cover;">
             </div>
             <div class="col-md-8" style="background-color: rgb(0, 0, 0, 0.04); height:100px;">
-                <h3 style="margin-bottom:0; margin-top:20px;" id="review_detail_spot_title">${spotCount}. ${spot.title}</h3>
+                <h3 style="margin-bottom:0; margin-top:20px;" id="review_detail_spot_title">${spotData.order}. ${spotData.spot.title}</h3>
                 <span class="price" id="review_detail_spot_addr">${spot_addr}</span>
             </div>
         </a>`
-        spotCount += 1
     }
 
     // 평점이 하나도 없을 시
@@ -253,7 +251,12 @@ async function viewRouteDetail() {
     if (route.image === null) {
         route_image.style.display = "none"
     }
-    createMarker(spot_ids)
+
+    let spotList = [];
+    spots.forEach(spotObj => {
+        spotList.push(spotObj.spot);
+    });
+    createMarker(spotList)
 }
 
 // 여행루트 삭제 함수

--- a/routes/detail/route_detail.js
+++ b/routes/detail/route_detail.js
@@ -331,7 +331,7 @@ async function getComments(route_id) {
             <div class="row g-3">
                 <div class="col-md-1">
                     <div class="card-body">
-                        <p class="card-text"><b>${comment.user.nickname}</b></p>
+                        <a href="/users/mypage/index.html?id=${comment.user.id}" id="commnet-name"><b>${comment.user.nickname}</b></a>
                     </div>
                 </div>
                 <div class="col-md-8">

--- a/routes/detail/update/index.html
+++ b/routes/detail/update/index.html
@@ -125,7 +125,7 @@
                                 <div class="col-xxs-12 col-xs-6 mt alternate">
                                     <div class="input-field">
                                         <label for="duration">여행 일수:</label>
-                                        <input type="text" class="form-control" id="route-duration"
+                                        <input type="number" min="1" class="form-control" id="route-duration"
                                             placeholder="숫자로만 작성" />
                                     </div>
                                 </div>
@@ -133,7 +133,8 @@
                                 <div class="col-xxs-12 col-xs-6 mt alternate">
                                     <div class="input-field">
                                         <label for="cost">여행 비용:</label>
-                                        <input type="text" class="form-control" id="route-cost" placeholder="숫자로만 작성" />
+                                        <input type="number" min="0" class="form-control" id="route-cost"
+                                            placeholder="숫자로만 작성" />
                                     </div>
                                 </div>
 

--- a/routes/detail/update/route_update.js
+++ b/routes/detail/update/route_update.js
@@ -62,7 +62,6 @@ async function loadRoute() {
     spots.forEach(spotObj => {
         savedSpots.push(spotObj.spot);
     });
-    console.log(savedSpots)
 
     title.value = route.title;
     duration.value = route.duration;
@@ -102,6 +101,21 @@ function handleUpdateRoute(event) {
     sigungu = document.getElementById('route-sigungu').value;
     image = document.getElementById('route-image').files[0];
     content = document.getElementById('route-content').value;
+
+    // duration과 cost는 숫자로만 받아야함
+    const durationValue = parseInt(duration);
+    const costValue = parseInt(cost);
+
+    // duration과 cost는 양의 정수만 받아야함
+    if (isNaN(durationValue) || !Number.isInteger(durationValue) || durationValue < 1) {
+        alert("여행일수는 1이상의 숫자만 기재할 수 있습니다");
+        return;
+    }
+
+    if (isNaN(costValue) || !Number.isInteger(costValue) || costValue < 0) {
+        alert("여행비용은 0이상의 숫자만 기재할 수 있습니다");
+        return;
+    }
 
     // areas는 딕셔너리 형태이기 때문에 formData로 전송시 형변환이 필요
     const areas = JSON.stringify({ area: area, sigungu: sigungu });

--- a/routes/detail/update/route_update.js
+++ b/routes/detail/update/route_update.js
@@ -54,8 +54,15 @@ async function loadRoute() {
     // 해당 게시글 데이터 불러오기
     const route = await getRouteDetail()
 
-    // 해당 게시글의 목적지를 목적지 리스트에 추가
-    savedSpots = route.spots
+
+    const spots = route.spots
+
+
+    // 해당 게시글의 목적지데이터 중 목적지 정보만 가져옴 
+    spots.forEach(spotObj => {
+        savedSpots.push(spotObj.spot);
+    });
+    console.log(savedSpots)
 
     title.value = route.title;
     duration.value = route.duration;
@@ -108,9 +115,14 @@ function handleUpdateRoute(event) {
     formData.append('content', content);
 
     // 목적지를 순차적으로 기입
-    spotsId.forEach((spot) =>
-        formData.append('spots', spot)
-    )
+    let spots = [];
+    let order = 1;
+
+    for (let i = 0; i < spotsId.length; i++) {
+        let spotInfo = { spot: spotsId[i], order: order++, day: 1 };
+        spots.push(spotInfo);
+    }
+    formData.append('spots', JSON.stringify(spots));
 
     // 이미지가 있는 경우에만 formdata에 기입
     if (image) {

--- a/routes/index.html
+++ b/routes/index.html
@@ -114,8 +114,7 @@
 							<p>다른 사람들과 여행 루트를 공유해보세요!</p>
 
 							<div class="col-xs-12">
-								<button class="btn btn-primary btn-block"
-									onclick="location.href='create/index.html'">여행루트
+								<button class="btn btn-primary btn-block" onclick="handleCreateButton()">여행루트
 									작성하기</button>
 							</div>
 						</div>

--- a/routes/route_main.js
+++ b/routes/route_main.js
@@ -155,6 +155,16 @@ async function viewMoreRouteList(nextURL) {
     }
 }
 
-window.viewMoreRouteList = viewMoreRouteList
+function handleCreateButton() {
+    const accessToken = localStorage.getItem('access'); // 이 부분은 여러분의 로그인 상태를 확인하는 방식에 따라 달라집니다.
 
+    if (accessToken) { // 로그인이 된 경우
+        location.href = 'create/index.html'; // 작성 페이지로 이동
+    } else { // 로그인이 안 된 경우
+        alert("로그인이 필요한 서비스입니다."); // 경고 메시지 출력
+    }
+}
+
+window.viewMoreRouteList = viewMoreRouteList
+window.handleCreateButton = handleCreateButton
 viewRouteList()


### PR DESCRIPTION
## 작성, 상세, 수정페이지 수정
- 백엔드 Route모델에 spot 필드관련 변경에 따라 목적지 관련 항목들을 수정했습니다.

## cost, duration예외처리
- cost와 duration에 예외처리가 들어가있지 않던 현상을 수정했습니다.
- 더불어 cost와 duration의 html input태그를 text에서 number로 수정하고 min값을 추가해 기본적인 제한을 뒀습니다.

## 여행루트 메인페이지 작성 버튼 예외처리
- 기존에 작성페이지에서 내용을 작성하고 작성버튼을 클릭해야만 로그인 필요 알림을 받았는데, 메인페이지에서 루트작성 페이지로 진입하는 버튼을 클릭할 때 로그인 예외처리를 만들어 사용자가 헛된 고생을 하지 않게 수정했습니다.

## 댓글 작성자 클릭 시 작성자의 마이페이지로 이동
- 댓글에서도 상대방의 마이페이지로 이동할 수 있게 추가했습니다.