### PR TITLE
Feat/joriro

### DIFF
--- a/joriro/index.css
+++ b/joriro/index.css
@@ -17,6 +17,7 @@
 #result-show img {
     width: 100%;
     height: auto;
+    margin: 20px auto 20px auto;
 }
 
 .loader {
@@ -55,10 +56,6 @@
     100% {
         transform: rotate(360deg);
     }
-}
-
-img {
-    margin: 20px auto 20px auto;
 }
 
 .down_btn {


### PR DESCRIPTION
조리로 페이지에서 헤더 크기가 다른 페이지와 달랐던 문제를 해결했습니다.
이미지 태그가 결과 이미지에서만 쓰이는 줄 알고 css 에서 모든 이미지에 마진을 준 게 문제였습니다.
결과 이미지에만 마진을 적용함으로써 해결